### PR TITLE
fix(BC-158, BC-159): correct slash command syntax and macro invocation format

### DIFF
--- a/src/components/home/CommandCenterPage.tsx
+++ b/src/components/home/CommandCenterPage.tsx
@@ -119,7 +119,7 @@ export function CommandCenterPage() {
       (c) =>
         c.cmd.toLowerCase().includes(q) ||
         c.description.toLowerCase().includes(q) ||
-        c.params?.toLowerCase().includes(q),
+        c.options?.some((o) => o.name.toLowerCase().includes(q) || o.description.toLowerCase().includes(q)),
     );
   }, [search, activeBot]);
 

--- a/src/components/home/CommandCenterSidebar.tsx
+++ b/src/components/home/CommandCenterSidebar.tsx
@@ -287,7 +287,7 @@ export function CommandCenterSidebar({
                       <div className="flex items-center gap-3 px-5 py-3 bg-[#0d0d16]">
                         <HugeiconsIcon icon={Robot01Icon} size={14} className="text-muted-foreground" />
                         <span className="text-[10px] font-mono text-muted-foreground uppercase tracking-widest">
-                          Marco Macro Protocols work with either / or [] prefixes
+                          Marco Macros: use /macro name:macroname or []macroname
                         </span>
                       </div>
                     )}

--- a/src/components/home/CommandRow.tsx
+++ b/src/components/home/CommandRow.tsx
@@ -13,11 +13,20 @@ const botBadgeStyles: Record<string, string> = {
   pencil: 'text-violet-400 border-violet-400/40 bg-violet-950/20',
 };
 
+/** Build the Discord slash-command string: `/cmd opt1: opt2:` */
+function buildCopyText(command: BotCommand, useMention?: boolean): string {
+  if (!command.options?.length) return command.cmd;
+  const opts = command.options
+    .filter(o => useMention || o.name !== "mention")
+    .map((o) => `${o.name}:${o.default}`).join(' ');
+  return `${command.cmd} ${opts}`;
+}
+
 export function CommandRow({ command }: CommandRowProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(command.usage ?? command.cmd);
+    await navigator.clipboard.writeText(buildCopyText(command));
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -40,17 +49,24 @@ export function CommandRow({ command }: CommandRowProps) {
           {command.description}
         </p>
 
-        {command.params && (
-          <div className="text-xs font-mono text-muted-foreground">
-            <span className="text-primary">PARAMS:</span> {command.params}
+        {command.options && command.options.length > 0 && (
+          <div className="space-y-1">
+            {command.options.map((opt) => (
+              <div key={opt.name} className="text-xs font-mono text-muted-foreground flex items-center gap-2">
+                <span className="text-primary">{opt.name}:</span>
+                <span>{opt.description}</span>
+                {opt.required && (
+                  <span className="text-destructive/70 text-[10px] uppercase tracking-wider">required</span>
+                )}
+              </div>
+            ))}
           </div>
         )}
 
-        {command.usage && (
-          <div className="text-xs font-mono text-muted-foreground">
-            <span className="text-primary">USAGE:</span> {command.usage}
-          </div>
-        )}
+        <div className="text-xs font-mono text-muted-foreground">
+          <span className="text-primary">EXAMPLE:</span>{' '}
+          <span className="text-brackeys-yellow/80">{buildCopyText(command, true)}</span>
+        </div>
       </div>
 
       <Button

--- a/src/components/home/MacroRow.tsx
+++ b/src/components/home/MacroRow.tsx
@@ -25,7 +25,7 @@ export function MacroRow({ macro }: MacroRowProps) {
   };
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(`/${macro.name}`);
+    await navigator.clipboard.writeText(`/macro name:${macro.name}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -50,7 +50,7 @@ export function MacroRow({ macro }: MacroRowProps) {
                 : 'text-brackeys-yellow bg-brackeys-yellow-muted/20 border-brackeys-yellow/30'
             }`}
           >
-            /{macro.name}
+            []{macro.name}
           </code>
 
           {macro.aliases.length > 0 && (
@@ -60,7 +60,7 @@ export function MacroRow({ macro }: MacroRowProps) {
                   key={alias}
                   className="text-[10px] font-mono text-muted-foreground border border-muted/40 px-1.5 py-0.5 bg-card/30"
                 >
-                  /{alias}
+                  []{alias}
                 </span>
               ))}
             </div>

--- a/src/components/layout/CommandPalette.tsx
+++ b/src/components/layout/CommandPalette.tsx
@@ -89,7 +89,9 @@ export function CommandPalette() {
               >
                 <HugeiconsIcon icon={LegalHammerIcon} className="text-muted-foreground" />
                 <span>{cmd.cmd}</span>
-                <CommandShortcut>{cmd.usage}</CommandShortcut>
+                {cmd.options && (
+                  <CommandShortcut>{cmd.options.map((o) => `${o.name}:`).join(' ')}</CommandShortcut>
+                )}
               </CommandItem>
             ))}
           </CommandGroup>
@@ -106,7 +108,9 @@ export function CommandPalette() {
               >
                 <HugeiconsIcon icon={PencilIcon} className="text-muted-foreground" />
                 <span>{cmd.cmd}</span>
-                <CommandShortcut>{cmd.usage}</CommandShortcut>
+                {cmd.options && (
+                  <CommandShortcut>{cmd.options.map((o) => `${o.name}:`).join(' ')}</CommandShortcut>
+                )}
               </CommandItem>
             ))}
           </CommandGroup>
@@ -122,7 +126,7 @@ export function CommandPalette() {
                 onSelect={() => run(() => navigate({ to: '/command-center' }))}
               >
                 <HugeiconsIcon icon={Robot01Icon} className="text-muted-foreground" />
-                <span>{macro.name}</span>
+                <span>[]{macro.name}</span>
                 {macro.aliases.length > 0 && (
                   <CommandShortcut>{macro.aliases.slice(0, 2).join(', ')}</CommandShortcut>
                 )}

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -1,13 +1,21 @@
 export type BotId = 'hammer' | 'pencil' | 'marco';
 export type CommandBotId = Exclude<BotId, 'marco'>;
 
+export type CommandOptionName = "rule" | "user" | "mention" | "color" | "spoiler" | "expression";
+
+export interface CommandOption {
+  name: CommandOptionName;
+  default?: string;
+  description: string;
+  required?: boolean;
+}
+
 export interface BotCommand {
   id: string;
   bot: CommandBotId;
   cmd: string;
   description: string;
-  usage?: string;
-  params?: string;
+  options?: CommandOption[];
 }
 
 export interface Macro {
@@ -22,23 +30,24 @@ export const hammerCommands: BotCommand[] = [
     bot: 'hammer',
     cmd: '/rule',
     description: 'Returns information about a specific server rule.',
-    params: '1–11',
-    usage: '/rule [1-11]',
+    options: [
+      { name: 'rule', description: 'Rule number (1–11)', required: true, default: "1" },
+    ],
   },
   {
     id: 'hammer-selfhistory',
     bot: 'hammer',
     cmd: '/selfhistory',
     description: 'Returns your own infraction history on the server.',
-    usage: '/selfhistory',
   },
   {
     id: 'hammer-userinfo',
     bot: 'hammer',
     cmd: '/userinfo',
     description: 'Returns base level information about a Discord member.',
-    params: '@user',
-    usage: '/userinfo [@user]',
+    options: [
+      { name: 'user', description: 'The user to look up', required: true, default:"@yasahiro" },
+    ],
   },
 ];
 
@@ -49,16 +58,21 @@ export const pencilCommands: BotCommand[] = [
     cmd: '/color',
     description:
       'Displays detailed information about a color. Accepts any color format such as hex, hsl, cmyk, and more.',
-    params: 'any color format (hex, hsl, cmyk, ...)',
-    usage: '/color [#hex | hsl() | cmyk() | ...]',
+    options: [
+      { name: 'color', description: 'The color to display (hex, rgb, hsl, cmyk)', required: true, default: "#fff" },
+      { name: 'mention', description: 'User to mention with the result', default:"@joshcomplex" },
+    ],
   },
   {
     id: 'pencil-tex',
     bot: 'pencil',
     cmd: '/tex',
     description: 'Nicely renders TeX formatted content inline in Discord.',
-    params: 'any TeX formula',
-    usage: '/tex [formula]',
+    options: [
+      { name: 'expression', description: 'The TeX expression to render', required: true, default: "\\sqrt{b^2 - 4ac}" },
+      { name: 'spoiler', description: 'Hide the result as a spoiler', default: "True" },
+      { name: 'mention', description: 'User to mention with the result', default:"@mellobacon" },
+    ],
   },
 ];
 


### PR DESCRIPTION
Update Command Center to use proper Discord slash command structure with named options (e.g. /tex expression: spoiler: mention:) instead of generic usage strings. Marco macros now copy as /macro name:<name> while displaying the short []name format.