### PR TITLE
chore(BC-161): pin undici to ^7.24.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,9 @@
       },
     },
   },
+  "overrides": {
+    "undici": "^7.24.6",
+  },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
 
@@ -1813,7 +1816,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
+    "undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -115,5 +115,9 @@
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0",
     "vitest": "^3.0.5"
+  },
+  "overrides": {
+
+    "undici": "^7.24.6" 
   }
 }


### PR DESCRIPTION
We will be forced to remove this once the upstream dep (@tanstack/react-start and its dep cheerios) resolves this vulnerability.

Addresses CVEs:
- CVE-2026-1525
- CVE-2026-2229
- CVE-2026-1528
- CVE-2026-1526
- CVE-2026-2581
- CVE-2026-1527